### PR TITLE
Raspberry Pi3 (aarch64): Fix DMA mapping

### DIFF
--- a/arch/arm64/include/asm/dma-mapping.h
+++ b/arch/arm64/include/asm/dma-mapping.h
@@ -19,7 +19,11 @@
 #ifdef __KERNEL__
 
 #include <linux/types.h>
-#include <linux/vmalloc.h>
+#include <linux/scatterlist.h>
+#include <linux/dma-attrs.h>
+#include <linux/dma-debug.h>
+
+#include <asm/memory.h>
 
 #include <xen/xen.h>
 #include <asm/xen/hypervisor.h>
@@ -56,6 +60,83 @@ void arch_teardown_dma_ops(struct device *dev);
 #define arch_teardown_dma_ops	arch_teardown_dma_ops
 #endif
 
+/*
+ * dma_to_pfn/pfn_to_dma/dma_to_virt/virt_to_dma are architecture private
+ * functions used internally by the DMA-mapping API to provide DMA
+ * addresses. They must not be used by drivers.
+ */
+#ifndef __arch_pfn_to_dma
+static inline dma_addr_t pfn_to_dma(struct device *dev, unsigned long pfn)
+{
+   if (dev)
+      pfn -= dev->dma_pfn_offset;
+   return (dma_addr_t)__pfn_to_bus(pfn);
+}
+
+static inline unsigned long dma_to_pfn(struct device *dev, dma_addr_t addr)
+{
+   unsigned long pfn = __bus_to_pfn(addr);
+
+   if (dev)
+      pfn += dev->dma_pfn_offset;
+
+   return pfn;
+}
+
+static inline void *dma_to_virt(struct device *dev, dma_addr_t addr)
+{
+   if (dev) {
+      unsigned long pfn = dma_to_pfn(dev, addr);
+
+      return phys_to_virt(__pfn_to_phys(pfn));
+   }
+
+   return (void *)__bus_to_virt((unsigned long)addr);
+}
+
+static inline dma_addr_t virt_to_dma(struct device *dev, void *addr)
+{
+   if (dev)
+      return pfn_to_dma(dev, virt_to_pfn(addr));
+
+   return (dma_addr_t)__virt_to_bus((unsigned long)(addr));
+}
+
+#else
+static inline dma_addr_t pfn_to_dma(struct device *dev, unsigned long pfn)
+{
+   return __arch_pfn_to_dma(dev, pfn);
+}
+
+static inline unsigned long dma_to_pfn(struct device *dev, dma_addr_t addr)
+{
+   return __arch_dma_to_pfn(dev, addr);
+}
+
+static inline void *dma_to_virt(struct device *dev, dma_addr_t addr)
+{
+   return __arch_dma_to_virt(dev, addr);
+}
+
+static inline dma_addr_t virt_to_dma(struct device *dev, void *addr)
+{
+   return __arch_virt_to_dma(dev, addr);
+}
+#endif
+
+/* The ARM override for dma_max_pfn() */
+static inline unsigned long dma_max_pfn(struct device *dev)
+{
+   return PHYS_PFN_OFFSET + dma_to_pfn(dev, *dev->dma_mask);
+}
+#define dma_max_pfn(dev) dma_max_pfn(dev)
+
+#define arch_setup_dma_ops arch_setup_dma_ops
+extern void arch_setup_dma_ops(struct device *dev, u64 dma_base, u64 size,
+                struct iommu_ops *iommu, bool coherent);
+
+
+
 /* do not use this function in a driver */
 static inline bool is_device_dma_coherent(struct device *dev)
 {
@@ -66,20 +147,31 @@ static inline bool is_device_dma_coherent(struct device *dev)
 
 static inline dma_addr_t phys_to_dma(struct device *dev, phys_addr_t paddr)
 {
-	return (dma_addr_t)paddr;
+	unsigned int offset = paddr & ~PAGE_MASK;
+	return pfn_to_dma(dev, __phys_to_pfn(paddr)) + offset;
 }
 
 static inline phys_addr_t dma_to_phys(struct device *dev, dma_addr_t dev_addr)
 {
-	return (phys_addr_t)dev_addr;
+	unsigned int offset = dev_addr & ~PAGE_MASK;
+	return __pfn_to_phys(dma_to_pfn(dev, dev_addr)) + offset;
 }
 
 static inline bool dma_capable(struct device *dev, dma_addr_t addr, size_t size)
 {
+	u64 limit, mask;
 	if (!dev->dma_mask)
-		return false;
+		return 0;
 
-	return addr + size - 1 <= *dev->dma_mask;
+	mask = *dev->dma_mask;
+	limit = (mask + 1) & ~mask;
+	if (limit && size > limit)
+		return 0;
+
+	if ((addr | (addr + size - 1)) & ~mask)
+		return 0;
+
+	return 1;
 }
 
 static inline void dma_mark_clean(void *addr, size_t size)

--- a/arch/arm64/include/asm/memory.h
+++ b/arch/arm64/include/asm/memory.h
@@ -160,6 +160,14 @@ static inline void *phys_to_virt(phys_addr_t x)
 
 #endif
 
+#ifndef __virt_to_bus
+#define __virt_to_bus   __virt_to_phys
+#define __bus_to_virt   __phys_to_virt
+#define __pfn_to_bus(x)   __pfn_to_phys(x)
+#define __bus_to_pfn(x)   __phys_to_pfn(x)
+#endif
+
+
 #include <asm-generic/memory_model.h>
 
 #endif

--- a/arch/arm64/mm/dma-mapping.c
+++ b/arch/arm64/mm/dma-mapping.c
@@ -208,8 +208,10 @@ static dma_addr_t __swiotlb_map_page(struct device *dev, struct page *page,
 
 	dev_addr = swiotlb_map_page(dev, page, offset, size, dir, attrs);
 	if (!is_device_dma_coherent(dev))
+	{
+		//  dev_err(dev, "Mapping non coherent DMA %08lx\n", dev_addr );
 		__dma_map_area(phys_to_virt(dma_to_phys(dev, dev_addr)), size, dir);
-
+	}
 	return dev_addr;
 }
 

--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -870,8 +870,7 @@ static int dwc2_assign_and_init_hc(struct dwc2_hsotg *hsotg, struct dwc2_qh *qh)
 		chan->xfer_dma = urb->dma + urb->actual_length;
 
 		/* For non-dword aligned case */
-		if (hsotg->core_params->dma_desc_enable <= 0 &&
-		    (chan->xfer_dma & 0x3))
+		if (chan->xfer_dma & 0x3)
 			bufptr = (u8 *)urb->buf + urb->actual_length;
 	} else {
 		chan->xfer_buf = (u8 *)urb->buf + urb->actual_length;


### PR DESCRIPTION
- Fix the dma mappings for the aarch64 platform on the raspberry pi3 b.
  As a base, the dma mapping of the arm platform was used.

Original author: Electron752
https://www.raspberrypi.org/forums/viewtopic.php?p=945097#p945097
